### PR TITLE
Unlimited memory - to avoid error on line 43

### DIFF
--- a/phpMalCodeScanner.php
+++ b/phpMalCodeScanner.php
@@ -73,6 +73,8 @@ class phpMalCodeScan {
 
 ############################################ INITIATE CLASS
 
+ini_set('memory_limit', '-1'); ## Avoid memory errors (i.e in foreachloop)
+
 new phpMalCodeScan;
 
 


### PR DESCRIPTION
Got error 
Fatal error: Allowed memory size of x bytes exhausted (tried to allocate y>x bytes) in phpMalCodeScanner.php on line 43
and fixed it
